### PR TITLE
Constrain `numba >=0.55.2` for `numpy >=1.22` compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@tomvothecoder](https://github.com/tomvothecoder/)
 * [@jasonb5](https://github.com/jasonb5/)
+* [@tomvothecoder](https://github.com/tomvothecoder/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b82c09532d0ca139bb608e3cdc2abe8e4931c74231b7a9aa2f819cab8a5a4932
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -28,7 +28,7 @@ requirements:
     - xesmf
     - netcdf4
     - numpy
-    - numba
+    - numba >=0.55.2
     - pandas
     - xarray
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
- Closes #5 

<!--
Please add any other relevant info below:
-->
