### PR TITLE
Update v0.5.0 recipe to constrain `cf_xarray >=0.7.3`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-fix-attrs-dropping.patch
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
     - setuptools
   run:
     - python >=3.9
-    - cf_xarray
-    - cftime >=0.7.3 # Constrained because https://github.com/xarray-contrib/cf-xarray/issues/467
+    - cf_xarray >=0.7.3 # Constrained because https://github.com/xarray-contrib/cf-xarray/issues/467
+    - cftime
     - dask
     - lxml  # TODO: Remove this in v0.7.0 once cdml/XML support is dropped
     - netcdf4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python >=3.9
     - cf_xarray
-    - cftime
+    - cftime >=0.7.3 # Constrained because https://github.com/xarray-contrib/cf-xarray/issues/467
     - dask
     - lxml  # TODO: Remove this in v0.7.0 once cdml/XML support is dropped
     - netcdf4


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
- Closes #24 

<!--
Please add any other relevant info below:
-->
